### PR TITLE
Completed open items from Ticket #137 (githelper)

### DIFF
--- a/githelper
+++ b/githelper
@@ -58,6 +58,7 @@
 #################################################################
 
 import os
+import pwd
 import sys
 import shlex
 import time
@@ -98,20 +99,23 @@ Commands:
 %prog setup
   Once user has created an account on github.com, this sets up everything to get started working 
 
-%prog clone -s STACK(s)
+%prog clone -s STACK(s) [-r] [-d install_dir, default=~/git/care-o-bot]
   Clones the given list (comma-separated) of repositories from github (if necessary, forks from ipa320 before cloning)
 
-%prog status [-s STACK(s), default=all stacks]
+%prog status [-s STACK(s), default=all stacks] [-d install_dir=~/git/care-o-bot]
   Executes 'git status -uno' 
 
-%prog pull [-s STACK(s), default=all stacks]
+%prog pull [-s STACK(s), default=all stacks] [-d install_dir=~/git/care-o-bot]
   Pulls latest changes from your origin master 
 
-%prog push [-s STACK(s), default=all stacks]
+%prog push [-s STACK(s), default=all stacks] [-d install_dir=~/git/care-o-bot]
   Pushes local commits to origin master 
 
-%prog merge [-u GITHUBUSER, default="ipa320"] | [-s STACK(s), default=all stacks]
+%prog merge [-u GITHUBUSER, default="ipa320"] [-s STACK(s), default=all stacks] [-d install_dir=~/git/care-o-bot]
   Merges from a remote branch 
+
+githelper -h
+  Further help on options
 """
 
 
@@ -120,6 +124,13 @@ Commands:
 # Parses arguments and starts helping. Everything is done regarding the local master branch
 #TODO: check for latest version before executing command
 def main():
+	# check for existence of curl; abort if not installed
+	curl_check = subprocess.Popen('which curl', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
+	if len(curl_check)==0:
+		print "Please install curl first: sudo apt-get install curl"
+		print "Aborting."
+		sys.exit(1)
+
 	#print "main ..."
 	parser = OptionParser(usage=_usage, prog=os.path.basename(sys.argv[0]))
 	
@@ -134,6 +145,10 @@ def main():
 	parser.add_option("-d", "--directory",
 		dest="install_dir", default="~/git/care-o-bot",
 		help="Installation directory of care-o-bot stacks. Default: ~/git/care-o-bot")
+
+	parser.add_option("-r", "--readonly",
+		action="store_true", dest="readonly",
+		help="Access github repositories read-only")
 	
 	(options, args) = parser.parse_args()
 
@@ -167,7 +182,30 @@ def main():
 			print 'Aborting...'
 			sys.exit(1)
 
-		# github user name
+		# setup global git user.name and user.email and set github.name and github.email to the same
+		git_username = subprocess.Popen('git config --global user.name', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
+		if len(git_username) > 0:
+			print 'Found the following global git user.name: ' + git_username
+			answer = raw_input('Should this setting be kept? [<Return>=Yes; or enter another name]: ')
+			if len(answer) > 0:
+				git_username = answer
+		else:
+			git_username = raw_input('Please enter your full name: ')
+		os.system('git config --global user.name "' + git_username + '"') #+ ' >> ' + _output + ' 2>&1') # store github user name in ~/.gitconfig
+		os.system('git config --global github.name "' + git_username + '"') # + ' >> ' + _output + ' 2>&1') # store github user name in ~/.gitconfig
+
+		git_useremail = subprocess.Popen('git config --global user.email', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
+		if len(git_useremail) > 0:
+			print 'Found the following global git user.email: ' + git_useremail
+			answer = raw_input('Should this setting be kept? [<Return>=Yes; or enter another user email]: ')
+			if len(answer) > 0:
+				git_useremail = answer
+		else:
+			git_useremail = raw_input('Please enter your email address: ')
+		os.system('git config --global user.email "' + git_useremail + '" >> ' + _output + ' 2>&1') # store github user email in ~/.gitconfig
+		os.system('git config --global github.email "' + git_useremail + '" >> ' + _output + ' 2>&1') # store github user email in ~/.gitconfig
+
+		# setup global github user name
 		github_user = subprocess.Popen('git config --global github.user', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
 		if len(github_user) > 0:
 			answer = raw_input('Is "' + github_user + '" your github user name? [<Return>=Yes; or enter another user name]: ')
@@ -175,7 +213,7 @@ def main():
 				github_user = answer
 		else:
 			github_user = raw_input('Please enter your github user name: ')
-		os.system('git config --global github.user ' + github_user + ' >> ' + _output + ' 2>&1') # store github user name in ~/.gitconfig
+		os.system('git config --global github.user "' + github_user + '" >> ' + _output + ' 2>&1') # store github user name in ~/.gitconfig
 
 		# github password
 		print 'Please enter your github password: '
@@ -203,21 +241,23 @@ def main():
 		
 		answer = raw_input('id_rsa key found in ~/.ssh/id_rsa; upload public key to github? [<any key> (recommended) / n] : ')
 		if answer != 'n':
-			rsaTitle = os.getlogin() + '@' + socket.gethostname()
+			rsaTitle = pwd.getpwuid(os.getuid())[0] + '@' + socket.gethostname()
 			f = open(os.path.expanduser('~/.ssh/id_rsa.pub'), 'r')
 			rsaKey = f.read().strip()
 			f.close()
 			tt = 'curl -i -H "Accept: application/json" -H "Content-Type: application/json" --user ' + github_user + ':' + github_pw + ' -X POST -d \'{"title":"' + rsaTitle + '","key":"' + rsaKey + '"}\' https://api.github.com/user/keys'
 			output = subprocess.Popen(tt, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
-			if re.search('Validation Failed', output):
-				print 'Key upload was unsuccessful.'
-				if re.search('key is already in use', output):
-					print 'Key is already uploaded to github; aborting...'
+			if re.search('key is already in use', output):
+				print 'Key is already uploaded to github; done.'
+			elif re.search('Validation Failed', output):
+				print 'Key upload was unsuccessful: Validation failed. Aborting...'
 				sys.exit(1)
 			else:
 				print 'Successfully uploaded the key ' + rsaTitle
 
 		# display info for user to be added to his ~/.bashrc file
+		print "\n"
+		print "Setup completed."
 		print "\n"
 		print "Please update your ROS_PACKAGE_PATH to include ~/git/care-o-bot: Either run the following line"
 		print "on each terminal or add the line at the end of your ~/.bashrc file and source it again."
@@ -231,75 +271,104 @@ def main():
 		if len(options.stacks)==0:
 			print 'Please provide a comma-separated list of stacks to clone; example:'
 			print 'githelper clone -s cob_command_tools,cob_robots'
-			print 'Aborting...\n'
+			print 'Optional arguments: -r (read-only), -d target_directory'
+			print 'Aborting.\n'
 			sys.exit(1)
-	
-		github_user = subprocess.Popen('git config --global github.user', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
-		if len(github_user) > 0:
-			answer = raw_input('Is "' + github_user + '" your github user name? [<Return>=Yes; or enter another user name]: ')
-			if len(answer) > 0:
-				github_user = answer
-		else:
-			github_user = raw_input('Please enter your github user name: ')
-	
-		# github password
-		print 'Please enter your github password: '
-		github_pw = getpass.getpass()
-
-		# try authentication on github
-		s = 'curl -u "' + github_user + ':' + github_pw + '" https://api.github.com'
-		answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
-		m = re.search('Bad credentials', answer)
-		if m:
-			print 'Login on github failed; wrong password? - aborting.\n'
-			sys.exit(1)
-		else:
-			print 'Login on github successful.\n'
 
 		stacks = options.stacks.split(',')
-		install_dir = os.path.expanduser(options.install_dir)
-		if not(os.path.exists( install_dir )):
-			os.makedirs( install_dir )
-		print 'Cloning into ' + install_dir
+	
+		if options.readonly==True: # no github account needed for readonly access
+			github_user = raw_input("Please enter github user from which to clone read-only (Enter = ipa320): ")
+			if len(github_user)==0:
+				github_user = "ipa320"
+			install_dir = os.path.expanduser(options.install_dir)
+			if not(os.path.exists( install_dir )):
+				os.makedirs( install_dir )
+			print 'Cloning into ' + install_dir
 
-		# get list of user repositories
-		answer = subprocess.Popen('curl https://api.github.com/users/' + github_user + '/repos', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
-		repos = json.loads(answer)
-		github_user_stacks = []
-		for rep in repos:
-			github_user_stacks.append(rep['name'])
+			for stack in stacks:
+				print 'Stack: ' + stack
+				if os.path.exists( os.path.join(install_dir, stack) ):
+					print "Already cloned into the specified directory; ignoring. Consider 'githelper pull' to get the latest changes."
+				else:
+					s = 'git clone git://github.com/' + github_user + '/' + stack + ' ' + os.path.join(install_dir, stack)
+					answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+					if re.search('fatal', answer[1]):
+						print 'Repository ' + stack + ' could not be cloned. git error message:'
+						print answer[1] + '\n'
+				print "Done."
+		else:
+			# if git user.name or user.email are not set, prompt user to run 'githelper setup first' and abort.
+			git_username = subprocess.Popen('git config --global user.name', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
+			git_useremail = subprocess.Popen('git config --global user.email', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
+			github_user = subprocess.Popen('git config --global github.user', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
+			if len(git_username)==0 or len(git_useremail)==0 or len(github_user)==0:
+				print "Missing git/github user information. Please run 'githelper setup' first."
+				print 'Aborting.\n'
+				sys.exit(1)
 
-		# get list of ipa320 repositories
-		answer = subprocess.Popen('curl https://api.github.com/users/ipa320/repos', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
-		repos = json.loads(answer)
-		github_ipa_stacks = []
-		for rep in repos:
-			github_ipa_stacks.append(rep['name'])
-		
-		for stack in stacks:
-			print 'Stack: ' + stack
-			if os.path.exists( os.path.join(install_dir, stack) ):
-				print "Already cloned into the specified directory; ignoring. Consider 'githelper pull' to get the latest changes."
-			elif stack in github_user_stacks:
-				s = 'git clone git@github.com:' + github_user + '/' + stack + ' ' + os.path.join(install_dir, stack)
-				answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-				if re.search('fatal', answer[1]):
-					print 'Repository ' + stack + ' could not be cloned. git error message:'
-					print answer[1] + '\n'
-			elif stack in github_ipa_stacks: # first fork, then clone
-				print 'Repository not forked yet. Now forking from ipa320...'
-				s = 'curl -u "' + github_user + ':' + github_pw + '" -X POST https://api.github.com/repos/ipa320/' + stack + '/forks'
-				subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-				print 'Now cloning...'
-				s = 'git clone git@github.com:' + github_user + '/' + stack + ' ~/git/care-o-bot/' + stack
-				answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-				if re.search('fatal', answer[1]):
-					print 'Repository ' + stack + ' could not be cloned. git error message:'
-					print answer[1] + '\n'
-			else: # neither in user nor in ipa repository
-				print 'This stack does not exist in ipa320 or in your personal github repository; ignoring.'
-			print 'Done.\n'
+			github_user = subprocess.Popen('git config --global github.user', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()
+			if len(github_user) > 0:
+				answer = raw_input('Is "' + github_user + '" your github user name? [<Return>=Yes; or enter another user name]: ')
+				if len(answer) > 0:
+					github_user = answer
+			else:
+				github_user = raw_input('Please enter your github user name: ')
 
+			# github password
+			print 'Please enter your github password: '
+			github_pw = getpass.getpass()
+
+			# try authentication on github
+			s = 'curl -u "' + github_user + ':' + github_pw + '" https://api.github.com'
+			answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
+			m = re.search('Bad credentials', answer)
+			if m:
+				print 'Login on github failed; check password or consider accessing remote repository read-only (githelper clone -r).'
+				print 'Aborting.\n'
+				sys.exit(1)
+			else:
+				print 'Login on github successful.\n'
+
+			install_dir = os.path.expanduser(options.install_dir)
+			if not(os.path.exists( install_dir )):
+				os.makedirs( install_dir )
+			print 'Cloning into ' + install_dir
+
+			# get list of user repositories
+			answer = subprocess.Popen('curl -u "' + github_user + ':' + github_pw + '" https://api.github.com/users/' + github_user + '/repos', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
+			repos = json.loads(answer)
+			github_user_stacks = []
+			for rep in repos:
+				github_user_stacks.append(rep['name'])
+
+			# get list of ipa320 repositories
+			answer = subprocess.Popen('curl -u "' + github_user + ':' + github_pw + '" https://api.github.com/users/ipa320/repos', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
+			repos = json.loads(answer)
+			github_ipa_stacks = []
+			for rep in repos:
+				github_ipa_stacks.append(rep['name'])
+			for stack in stacks:
+				print 'Stack: ' + stack
+				if os.path.exists( os.path.join(install_dir, stack) ):
+					print "Already cloned into the specified directory; ignoring. Consider 'githelper pull' to get the latest changes."
+				elif stack in github_user_stacks:
+					s = 'git clone git@github.com:' + github_user + '/' + stack + ' ' + os.path.join(install_dir, stack)
+					answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+					if re.search('fatal', answer[1]):
+						print 'Repository ' + stack + ' could not be cloned. git error message:'
+						print answer[1] + '\n'
+				else:
+					print 'Repository not forked yet. Now forking from ipa320...'
+					s = 'curl -u "' + github_user + ':' + github_pw + '" -X POST https://api.github.com/repos/ipa320/' + stack + '/forks'
+					subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+					print 'Now cloning...'
+					s = 'git clone git@github.com:' + github_user + '/' + stack + ' ~/git/care-o-bot/' + stack
+					answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+					if re.search('fatal', answer[1]):
+						print 'Repository ' + stack + ' could not be cloned. git error message:'
+						print answer[1] + '\n'
+				print 'Done.\n'
 
 
 # ./githelper fork -s blub,cob_command_tools,bla,cob_navigation,cob_manipulation,cob_common
@@ -402,7 +471,7 @@ def git_merge(stack, options):
 	status = p.read()
 	p.close()
 	if status.count("origin-" + options.githubuser) <= 0:
-		os.system("git remote add origin-" + options.githubuser + " git@github.com:" + options.githubuser + "/" + stack + ".git")
+		os.system("git remote add origin-" + options.githubuser + " git@github.com:" + options.githubuser + "/" + stack)
 
 	# change to automerge branch
 	os.system("git checkout -b automerge >> " + _output + " 2>&1")


### PR DESCRIPTION
- Several changes in wording of output messages and help output.
- Fixed bugs in githelper setup, and added missing .gitconfig fields
- Added a "read-only" flag (-r) to githelper clone; can be used to clone from github without a github account
- For read-write cloning, added a check that all essential info in .gitconfig is there
- githelper clone fixed bug that didn't allow to clone ipa320 readonly version
- Fixed bug that did not allow cloning of private stacks
- Fixed wrong remote branch name issue in "githelper merge" (had a .git ending which should not be there)
