### PR TITLE
Further changes to githelper, as discussed (Trac ticket 137)

### DIFF
--- a/githelper
+++ b/githelper
@@ -327,41 +327,25 @@ def main():
 			install_dir = os.path.expanduser(options.install_dir)
 			if not(os.path.exists( install_dir )):
 				os.makedirs( install_dir )
-			print 'Cloning into ' + install_dir
-
-			# get list of user repositories
-			answer = subprocess.Popen('curl -u "' + github_user + ':' + github_pw + '" https://api.github.com/users/' + github_user + '/repos', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
-			repos = json.loads(answer)
-			github_user_stacks = []
-			for rep in repos:
-				github_user_stacks.append(rep['name'])
-
-			# get list of ipa320 repositories
-			answer = subprocess.Popen('curl -u "' + github_user + ':' + github_pw + '" https://api.github.com/users/ipa320/repos', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0]
-			repos = json.loads(answer)
-			github_ipa_stacks = []
-			for rep in repos:
-				github_ipa_stacks.append(rep['name'])
+			print 'Cloning into ' + install_dir + '\n'
 			for stack in stacks:
 				print 'Stack: ' + stack
 				if os.path.exists( os.path.join(install_dir, stack) ):
 					print "Already cloned into the specified directory; ignoring. Consider 'githelper pull' to get the latest changes."
-				elif stack in github_user_stacks:
+				else:
 					s = 'git clone git@github.com:' + github_user + '/' + stack + ' ' + os.path.join(install_dir, stack)
 					answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
 					if re.search('fatal', answer[1]):
-						print 'Repository ' + stack + ' could not be cloned. git error message:'
-						print answer[1] + '\n'
-				else:
-					print 'Repository not forked yet. Now forking from ipa320...'
-					s = 'curl -u "' + github_user + ':' + github_pw + '" -X POST https://api.github.com/repos/ipa320/' + stack + '/forks'
-					subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-					print 'Now cloning...'
-					s = 'git clone git@github.com:' + github_user + '/' + stack + ' ~/git/care-o-bot/' + stack
-					answer = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-					if re.search('fatal', answer[1]):
-						print 'Repository ' + stack + ' could not be cloned. git error message:'
-						print answer[1] + '\n'
+						print 'Repository "' + stack + '" not found in repositories of github user "' + github_user + '".'
+						print 'Now trying to fork from ipa320...'
+						s = 'curl -u "' + github_user + ':' + github_pw + '" -X POST https://api.github.com/repos/ipa320/' + stack + '/forks'
+						subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+						print 'Now trying to clone...'
+						s = 'git clone git@github.com:' + github_user + '/' + stack + ' ~/git/care-o-bot/' + stack
+						answer2 = subprocess.Popen(s, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+						if re.search('fatal', answer2[1]):
+							print 'Repository ' + stack + ' could not be cloned. git error message:'
+							print answer2[1] + '\n'
 				print 'Done.\n'
 
 


### PR DESCRIPTION
- fixed bug that printed "forking" for private repositories even if no forking was needed
- simplified 'githelper setup' user interaction
- added messages in 'githelper setup' and 'githelper clone' to alert user of possibility to clone read-only using the -r option to 'githelper setup'
