### PR TITLE
fix udev rules for usb2serial device for laser scanner

### DIFF
--- a/udev_rules/01-cob.rules
+++ b/udev_rules/01-cob.rules
@@ -14,10 +14,6 @@ SUBSYSTEM=="usb",ATTR{idVendor}=="046d",ATTR{idProduct}=="c219",SYMLINK+="joypad
 #Logitech Webcam
 SUBSYSTEM=="usb",ATTR{idVendor}=="046d",ATTR{idProduct}=="0809",SYMLINK+="video",GROUP="users"
 
-#Laserscanner
-SUBSYSTEM=="tty",ATTRS{bInterfaceNumber}=="00",ATTRS{../idProduct}=="6010",MODE="0666",SYMLINK+="ttyScan0"
-SUBSYSTEM=="tty",ATTRS{bInterfaceNumber}=="01",ATTRS{../idProduct}=="6010",MODE="0666",SYMLINK+="ttyScan1"
-
 #Relaisboard
 SUBSYSTEM=="tty",ATTRS{idVendor}=="0403",ATTRS{idProduct}=="6001",ATTRS{bcdDevice}=="0400",MODE="0666",SYMLINK+="ttyRelais"
 

--- a/udev_rules/90-usb-serial.rules
+++ b/udev_rules/90-usb-serial.rules
@@ -1,0 +1,4 @@
+# USB to Serial Adapter for Laserscanners
+SUBSYSTEM=="tty",ATTRS{bInterfaceNumber}=="00",ATTRS{../idProduct}=="6010",ATTRS{../idVendor}=="0403",MODE="0666",SYMLINK+="ttyScan0"
+SUBSYSTEM=="tty",ATTRS{bInterfaceNumber}=="01",ATTRS{../idProduct}=="6010",ATTRS{../idVendor}=="0403",MODE="0666",SYMLINK+="ttyScan1"
+


### PR DESCRIPTION
works on r@w3-1
Might be a possibility to get rid of the init.d script....
