### PR TITLE
issue and PR templates?

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description of Problem
+
+### Observed behavior
+What did you observe?
+
+### Expected behavior
+What did you expect?
+
+## Steps to reproduce the problem
+What did you do when the problem appeared?
+
+## Version / System Information
+Please check the corresponding check-boxes that describe your issue and add the respective information requested below:
+
+- Observed
+    - [ ] on robot
+    - [ ] in simulation
+- ROS Version
+    - [ ] indigo
+    - [ ] kinetic
+- branch
+    - [ ] indigo_dev
+    - [ ] kinetic_dev
+
+- Branch, if none of the above:
+- Commit SHA:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description of Problem
+
+### Observed behavior
+What did you observe?
+
+### Expected behavior
+What did you expect?
+
+## Steps to reproduce the problem
+What did you do when the problem appeared?
+
+## Version / System Information
+Please check the corresponding check-boxes that describe your issue and add the respective information requested below:
+
+- Observed
+    - [ ] on robot
+    - [ ] in simulation
+- ROS Version
+    - [ ] indigo
+    - [ ] kinetic
+- branch
+    - [ ] indigo_dev
+    - [ ] kinetic_dev
+
+- Branch, if none of the above:
+- Commit SHA:

--- a/templates/ISSUE_TEMPLATE.md
+++ b/templates/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description of Problem
+
+### Observed behavior
+What did you observe?
+
+### Expected behavior
+What did you expect?
+
+## Steps to reproduce the problem
+What did you do when the problem appeared?
+
+## Version / System Information
+Please check the corresponding check-boxes that describe your issue and add the respective information requested below:
+
+- Observed
+    - [ ] on robot
+    - [ ] in simulation
+- ROS Version
+    - [ ] indigo
+    - [ ] kinetic
+- branch
+    - [ ] indigo_dev
+    - [ ] kinetic_dev
+
+- Branch, if none of the above:
+- Commit SHA:


### PR DESCRIPTION
@ipa-fxm @ipa-fmw 
As a result of the discussion in ipa320/ipa_navigation_localization#188, I wondered if you could add some templates that would encourage people to add the correct/required information to issues or PRs. Thus, one would not have to request the information again.

In the end: [it is possible](https://help.github.com/articles/helping-people-contribute-to-your-project/).
The templates need to be in the root of the repo, or in a `.github` subdirectory (which I would prefer).

What do you think about something like that?
I quickly hacked together something for an issue, it should definitely be different for a PR.

To see what it looks like (the issue version, in a PR :stuck_out_tongue_closed_eyes: ), check out: https://github.com/ipa-mig/setup/compare/master...ipa-mig:test

What do you think?

(Obviously, the tmp commit should be reverted, and the templates be made more consistent...)
